### PR TITLE
[omxplayer] Flush EOS from queue to avoid it turning up after a seek

### DIFF
--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -495,6 +495,7 @@ void OMXPlayerAudio::Flush()
 {
   m_flush = true;
   m_messageQueue.Flush();
+  m_messageQueue.Flush(CDVDMsg::GENERAL_EOF);
   m_messageQueue.Put( new CDVDMsg(CDVDMsg::GENERAL_FLUSH), 1);
 }
 

--- a/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerVideo.cpp
@@ -535,6 +535,7 @@ void OMXPlayerVideo::Flush()
 {
   m_flush = true;
   m_messageQueue.Flush();
+  m_messageQueue.Flush(CDVDMsg::GENERAL_EOF);
   m_messageQueue.Put(new CDVDMsg(CDVDMsg::GENERAL_FLUSH), 1);
 }
 


### PR DESCRIPTION
A GENERAL_EOS is queued when demuxer reaches EOF but playback may
continue for several seconds. It should be possible to seek backwards
during this playback time, but the GENERAL_EOS may still be queued
after flushing and it unwantedly causes stream to stall after the seek.

So flush these obsolete messages when flushing data packets