### PR TITLE
[DVD] fix: libdvd's stream API doesn't handle incomplete reads well

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1589,7 +1589,7 @@ DVDNavVideoStreamInfo CDVDInputStreamNavigator::GetVideoStreamInfo()
 int dvd_inputstreamnavigator_cb_seek(void * p_stream, uint64_t i_pos)
 {
   CDVDInputStreamFile *lpstream = reinterpret_cast<CDVDInputStreamFile*>(p_stream);
-  if (lpstream->Seek(i_pos, 0) >= 0)
+  if (lpstream->Seek(i_pos, SEEK_SET) >= 0)
     return 0;
   else
     return -1;
@@ -1598,7 +1598,24 @@ int dvd_inputstreamnavigator_cb_seek(void * p_stream, uint64_t i_pos)
 int dvd_inputstreamnavigator_cb_read(void * p_stream, void * buffer, int i_read)
 {
   CDVDInputStreamFile *lpstream = reinterpret_cast<CDVDInputStreamFile*>(p_stream);
-  return lpstream->Read(reinterpret_cast<uint8_t *>(buffer), i_read);
+
+  int i_ret = 0;
+  while (i_ret < i_read)
+  {
+    int i_r;
+    i_r = lpstream->Read(reinterpret_cast<uint8_t *>(buffer) + i_ret, i_read - i_ret);
+    if (i_r < 0)
+    {
+      CLog::Log(LOGERROR,"read error dvd_inputstreamnavigator_cb_read");
+      return i_r;
+    }
+    if (i_r == 0)
+      break;
+
+    i_ret += i_r;
+  }
+
+  return i_ret;
 }
 
 int dvd_inputstreamnavigator_cb_readv(void * p_stream, void * p_iovec, int i_blocks)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
