### PR TITLE
Fix segfault when rapidly stopping/starting button mapping

### DIFF
--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -96,19 +96,17 @@ void CGUIConfigurationWizard::OnUnfocus(IFeatureButton* button)
 
 bool CGUIConfigurationWizard::Abort(bool bWait /* = true */)
 {
-  if (!m_bStop)
-  {
-    StopThread(false);
+  bool bWasRunning = !m_bStop;
 
-    m_inputEvent.Set();
-    m_motionlessEvent.Set();
+  StopThread(false);
 
-    if (bWait)
-      StopThread(true);
+  m_inputEvent.Set();
+  m_motionlessEvent.Set();
 
-    return true;
-  }
-  return false;
+  if (bWait)
+    StopThread(true);
+
+  return bWasRunning;
 }
 
 void CGUIConfigurationWizard::Process(void)


### PR DESCRIPTION
The segfault was due to a race condition where the thread was aborted
asynchronously. Upon recreation, Kodi attempts to block while the thread
is aborted, but fails to block because the thread is already aborting.
When Kodi creates a new thread before abortion finishes, things go boom.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
