### PR TITLE
Fix crash if song item artistid property is not an array i.e. an addo…

### DIFF
--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -92,15 +92,20 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
 
   std::string path(pItem->GetPath());
   // For songs in library set the (primary) song artist and album properties 
-  // Use song Id (not path) as called for items from either library or file view 
-  if (pItem->GetMusicInfoTag()->GetDatabaseId() > 0)
+  // Use song Id (not path) as called for items from either library or file view,
+  // but could also be listitem with tag loaded by a script
+  if (pItem->HasMusicInfoTag() && 
+      pItem->GetMusicInfoTag()->GetType() == MediaTypeSong && 
+      pItem->GetMusicInfoTag()->GetDatabaseId() > 0)
   {
     CMusicDatabase database;
     database.Open();
-    // May already have song artist ids as item property, otherwise fetch from song id
+    // May already have song artist ids as item property set when data read from
+    // db, but check property is valid array (scripts could set item properties 
+    // incorrectly), otherwise fetch artist using song id.
     CArtist artist;
     bool artistfound = false;
-    if (pItem->HasProperty("artistid"))
+    if (pItem->HasProperty("artistid") && pItem->GetProperty("artistid").isArray())
     {
       CVariant::const_iterator_array varid = pItem->GetProperty("artistid").begin_array();
       int idArtist = varid->asInteger();

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -65,8 +65,10 @@ public:
       return false;
     CFileItemPtr m_song = dialog->GetCurrentListItem();
 
-    // Fetch tag data from library using filename, or scanning file (if item not already have this loaded)
-    m_song->LoadMusicTag();
+    // Fetch tag data from library using filename of item path, or scanning file
+    // (if item does not already have this loaded)
+    if (!m_song->LoadMusicTag())
+      return false;
     if (dialog->IsCancelled())
       return false;
     // Fetch album and primary song artist data from library as properties


### PR DESCRIPTION
…n has set it incorrectly

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
