### PR TITLE
[pvr] Guide window: add confirmation doalog when user selects a futur…

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -1230,9 +1230,10 @@ msgctxt "#263"
 msgid "Allow remote control via HTTP"
 msgstr ""
 
-#. Label for a context menu entry to start/schedule a recording
+#. Label for a context menu entry / button to start/schedule a recording
 #: xbmc/music/windows/GUIWindowMusicBase.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRGuideInfo.cpp
+#: xbmc/pvr/windows/GUIWIndowPVRGuide.cpp
 #: xbmc/pvr/PVRContextMenus.cpp
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#264"
@@ -9972,7 +9973,9 @@ msgctxt "#19164"
 msgid "Could not start recording. Check the log for more information about this message."
 msgstr ""
 
+#. Label for "switch to channel" button""
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
+#: xbmc/pvr/windows/GUIWIndowPVRGuide.cpp
 msgctxt "#19165"
 msgid "Switch"
 msgstr ""
@@ -10785,7 +10788,13 @@ msgctxt "#19301"
 msgid "Horizontal channels, no group selector"
 msgstr ""
 
-#empty strings from id 19302 to 19498
+#. text for yes no dialog shown when user selects a future programme in the guide window and default select action is 'smart select'
+#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+msgctxt "#19302"
+msgid "Do you want to record the selected programme or to switch to the current programme?"
+msgstr ""
+
+#empty strings from id 19303 to 19498
 
 #. label for epg genre value
 #: xbmc/epg/Epg.cpp

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -29,6 +29,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "input/Key.h"
 #include "messaging/ApplicationMessenger.h"
+#include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
 #include "threads/SingleLock.h"
 #include "view/GUIViewState.h"
@@ -39,6 +40,7 @@
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/windows/GUIEPGGridContainer.h"
 
+using namespace KODI::MESSAGING;
 using namespace PVR;
 
 CGUIWindowPVRGuideBase::CGUIWindowPVRGuideBase(bool bRadio, int id, const std::string &xmlFile) :
@@ -397,7 +399,17 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                       if (tag->HasTimer())
                         CServiceBroker::GetPVRManager().GUIActions()->EditTimer(pItem);
                       else
-                        CServiceBroker::GetPVRManager().GUIActions()->AddTimer(pItem, false);
+                      {
+                        HELPERS::DialogResponse ret
+                          = HELPERS::ShowYesNoDialogText(CVariant{19096}, // "Smart select"
+                                                          CVariant{19302}, // "Do you want to record the selected programme or to switch to the current programme?"
+                                                          CVariant{264}, // No => "Record"
+                                                          CVariant{19165}); // Yes => "Switch"
+                        if (ret == HELPERS::DialogResponse::NO)
+                          CServiceBroker::GetPVRManager().GUIActions()->AddTimer(pItem, false);
+                        else if (ret == HELPERS::DialogResponse::YES)
+                          CServiceBroker::GetPVRManager().GUIActions()->SwitchToChannel(pItem, true);
+                      }
                     }
                     else
                     {


### PR DESCRIPTION
…e programme in the guide window and default select action is 'smart select'.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
