### PR TITLE
Games: Fix broken savestate location for standalone game clients

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -308,7 +308,7 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
     return false;
   }
 
-  if (!InitializeGameplay(ID(), streamManager, input))
+  if (!InitializeGameplay("", streamManager, input))
     return false;
 
   return true;

--- a/xbmc/games/addons/savestates/SavestateWriter.cpp
+++ b/xbmc/games/addons/savestates/SavestateWriter.cpp
@@ -42,6 +42,13 @@ CSavestateWriter::~CSavestateWriter() = default;
 
 bool CSavestateWriter::Initialize(const CGameClient* gameClient, uint64_t frameHistoryCount)
 {
+  //! @todo Handle savestates for standalone game clients
+  if (gameClient->GetGamePath().empty())
+  {
+    CLog::Log(LOGERROR, "Savestates not implemented for standalone game clients");
+    return false;
+  }
+
   m_savestate.Reset();
   m_fps = 0.0;
 
@@ -59,8 +66,6 @@ bool CSavestateWriter::Initialize(const CGameClient* gameClient, uint64_t frameH
   m_savestate.SetPlaytimeWallClock(frameHistoryCount / m_fps); //! @todo Accumulate playtime instead of deriving it
 
   m_savestate.SetPath(CSavestateUtils::MakePath(m_savestate));
-  if (m_savestate.Path().empty())
-    CLog::Log(LOGDEBUG, "Failed to calculate savestate path");
 
   if (m_fps == 0.0)
     return false; // Sanity check


### PR DESCRIPTION
Log output after applying fix:

   DEBUG: RetroPlayer[PLAYER]: Closing file
   ERROR: Savestates not implemented for standalone game clients
   DEBUG: RetroPlayer[SAVE]: Failed to save state at close

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
