### PR TITLE
RetroPlayer: Fix no game input after controller shuts off

### DIFF
--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -91,6 +91,9 @@ void CGameClientInput::Start()
 
   // Ensure hardware is open to receive events
   m_hardware.reset(new CGameClientHardware(m_gameClient));
+
+  if (CServiceBroker::IsServiceManagerUp())
+    CServiceBroker::GetPeripherals().RegisterObserver(this);
 }
 
 void CGameClientInput::Deinitialize()
@@ -100,6 +103,9 @@ void CGameClientInput::Deinitialize()
 
 void CGameClientInput::Stop()
 {
+  if (CServiceBroker::IsServiceManagerUp())
+    CServiceBroker::GetPeripherals().UnregisterObserver(this);
+
   m_hardware.reset();
 
   std::vector<std::string> ports;


### PR DESCRIPTION
This fixes input dropping and never resuming in the game when a controller
disconnects, such as for low-battery situations.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
