### PR TITLE
[videoplayer] Fix usage of external vob subtitles. While vob subs are…

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -29,6 +29,7 @@
 #include "threads/Thread.h"
 #include "utils/StreamDetails.h"
 #include "guilib/DispResource.h"
+#include <unordered_map>
 
 #ifdef TARGET_RASPBERRY_PI
 #include "OMXCore.h"
@@ -541,7 +542,8 @@ protected:
 
   std::shared_ptr<CDVDInputStream> m_pInputStream;
   CDVDDemux* m_pDemuxer;
-  CDVDDemux* m_pSubtitleDemuxer;
+  std::shared_ptr<CDVDDemux> m_pSubtitleDemuxer;
+  std::unordered_map<int64_t, std::shared_ptr<CDVDDemux>> m_subtitleDemuxerMap;
   CDVDDemuxCC* m_pCCDemuxer;
 
   CRenderManager m_renderManager;


### PR DESCRIPTION
… added to the selection streams, the id of a temporary demuxer was added.

But when the subtitle stream got opened/used, a new demuxer with another id was opened.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
