### PR TITLE
FullscreenGame: Remove OSD toggle

### DIFF
--- a/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
+++ b/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.cpp
@@ -80,10 +80,6 @@ bool CGameWindowFullScreen::OnAction(const CAction &action)
   switch (action.GetID())
   {
   case ACTION_SHOW_OSD:
-  {
-    ToggleOSD();
-    return true;
-  }
   case ACTION_TRIGGER_OSD:
   {
     TriggerOSD();
@@ -194,20 +190,6 @@ void CGameWindowFullScreen::OnDeinitWindow(int nextWindowID)
   CGUIWindow::OnDeinitWindow(nextWindowID);
 
   CServiceBroker::GetWinSystem()->GetGfxContext().SetFullScreenVideo(false); //! @todo
-}
-
-void CGameWindowFullScreen::ToggleOSD()
-{
-  CGUIDialog *pOSD = GetOSD();
-  if (pOSD != nullptr)
-  {
-    if (pOSD->IsDialogRunning())
-      pOSD->Close();
-    else
-      pOSD->Open();
-  }
-
-  MarkDirtyRegion();
 }
 
 void CGameWindowFullScreen::TriggerOSD()

--- a/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.h
+++ b/xbmc/cores/RetroPlayer/guiwindows/GameWindowFullScreen.h
@@ -44,7 +44,6 @@ namespace RETRO
     void OnInitWindow() override;
 
   private:
-    void ToggleOSD();
     void TriggerOSD();
     CGUIDialog *GetOSD();
 


### PR DESCRIPTION
We'll never need to close the OSD from the fullscreen game window, because
the fullscreen game window can only receive the toggle action if the OSD is
already closed.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
