### PR TITLE
Fix blank viz preset dialog when no viz or when viz not have presets

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -5136,6 +5136,7 @@ msgstr ""
 #empty string with id 10121
 
 #: xbmc/guilib/WindowIDs.h
+#: xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
 msgctxt "#10122"
 msgid "Visualization preset list"
 msgstr ""
@@ -6913,8 +6914,9 @@ msgctxt "#13388"
 msgid "Preset"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
 msgctxt "#13389"
-msgid "There are no presets available\nfor this visualisation"
+msgid "There are no presets available for this visualisation"
 msgstr ""
 
 msgctxt "#13390"
@@ -7004,6 +7006,7 @@ msgctxt "#13406"
 msgid "Picture information"
 msgstr ""
 
+#: xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
 msgctxt "#13407"
 msgid "{0:s} presets"
 msgstr ""

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -29,7 +29,7 @@ bool CGUIDialogVisualisationPresetList::OnMessage(CGUIMessage &message)
   switch (message.GetMessage())
   {
   case GUI_MSG_VISUALISATION_UNLOADING:
-    SetVisualisation(nullptr);
+    ClearVisualisation();
     break;
   }
   return CGUIDialogSelect::OnMessage(message);
@@ -41,11 +41,23 @@ void CGUIDialogVisualisationPresetList::OnSelect(int idx)
     m_viz->SetPreset(idx);
 }
 
+void CGUIDialogVisualisationPresetList::ClearVisualisation()
+{
+  m_viz = nullptr;
+  Reset();
+}
+
 void CGUIDialogVisualisationPresetList::SetVisualisation(CGUIVisualisationControl* vis)
 {
   m_viz = vis;
   Reset();
-  if (m_viz)
+  if (!m_viz)
+  { // No viz, but show something if this dialog activated
+    SetHeading(CVariant{ 10122 });
+    CFileItem item(g_localizeStrings.Get(13389));
+    Add(item);
+  }
+  else
   {
     SetUseDetails(false);
     SetMultiSelection(false);
@@ -61,6 +73,12 @@ void CGUIDialogVisualisationPresetList::SetVisualisation(CGUIVisualisationContro
       }
       SetSelected(m_viz->GetActivePreset());
     }
+    else
+    { // Viz does not have any presets
+      // "There are no presets available for this visualisation"
+      CFileItem item(g_localizeStrings.Get(13389));
+      Add(item);
+    }
   }
 }
 
@@ -68,13 +86,12 @@ void CGUIDialogVisualisationPresetList::OnInitWindow()
 {
   CGUIMessage msg(GUI_MSG_GET_VISUALISATION, 0, 0);
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
-  if (msg.GetPointer())
-    SetVisualisation(static_cast<CGUIVisualisationControl*>(msg.GetPointer()));
+  SetVisualisation(static_cast<CGUIVisualisationControl*>(msg.GetPointer()));
   CGUIDialogSelect::OnInitWindow();
 }
 
 void CGUIDialogVisualisationPresetList::OnDeinitWindow(int nextWindowID)
 {
-  SetVisualisation(nullptr);
+  ClearVisualisation();
   CGUIDialogSelect::OnDeinitWindow(nextWindowID);
 }

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.h
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.h
@@ -26,6 +26,7 @@ protected:
   void OnSelect(int idx) override;
 
 private:
+  void ClearVisualisation();
   void SetVisualisation(CGUIVisualisationControl *addon);
   CGUIVisualisationControl* m_viz = nullptr;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
