### PR TITLE
Merge pull request #16660 from Montellese/bug/addon_settings_fixes

### DIFF
--- a/xbmc/addons/settings/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.cpp
@@ -249,3 +249,11 @@ CSettingsManager* CGUIDialogAddonSettings::GetSettingsManager() const
 
   return m_addon->GetSettings()->GetSettingsManager();
 }
+
+void CGUIDialogAddonSettings::OnSettingAction(std::shared_ptr<const CSetting> setting)
+{
+  if (m_addon == nullptr || m_addon->GetSettings() == nullptr)
+    return;
+
+  m_addon->GetSettings()->OnSettingAction(setting);
+}

--- a/xbmc/addons/settings/GUIDialogAddonSettings.h
+++ b/xbmc/addons/settings/GUIDialogAddonSettings.h
@@ -39,6 +39,9 @@ protected:
   void Save() override { }
   CSettingsManager* GetSettingsManager() const override;
 
+  // implementation of ISettingCallback
+  void OnSettingAction(std::shared_ptr<const CSetting> setting) override;
+
 private:
   ADDON::AddonPtr m_addon;
   bool m_saveToDisk = false;

--- a/xbmc/settings/SettingControl.cpp
+++ b/xbmc/settings/SettingControl.cpp
@@ -138,7 +138,13 @@ bool CSettingControlButton::Deserialize(const TiXmlNode *node, bool update /* = 
   XMLUtils::GetInt(node, SETTING_XML_ELM_CONTROL_HEADING, m_heading);
   XMLUtils::GetBoolean(node, SETTING_XML_ELM_CONTROL_HIDEVALUE, m_hideValue);
 
-  if (m_format == "addon")
+  if (m_format == "action")
+  {
+    bool closeDialog = false;
+    if (XMLUtils::GetBoolean(node, "close", closeDialog))
+      m_closeDialog = closeDialog;
+  }
+  else if (m_format == "addon")
   {
     std::string strShowAddons;
     if (XMLUtils::GetString(node, "show", strShowAddons) && !strShowAddons.empty())
@@ -254,19 +260,28 @@ bool CSettingControlSlider::Deserialize(const TiXmlNode *node, bool update /* = 
 
 bool CSettingControlSlider::SetFormat(const std::string &format)
 {
-  if (StringUtils::EqualsNoCase(format, "percentage"))
-    m_formatString = "%i %%";
-  else if (StringUtils::EqualsNoCase(format, "integer"))
-    m_formatString = "%d";
-  else if (StringUtils::EqualsNoCase(format, "number"))
-    m_formatString = "%.1f";
-  else
+  if (!StringUtils::EqualsNoCase(format, "percentage") &&
+      !StringUtils::EqualsNoCase(format, "integer") &&
+      !StringUtils::EqualsNoCase(format, "number"))
     return false;
 
   m_format = format;
   StringUtils::ToLower(m_format);
+  m_formatString = GetDefaultFormatString();
 
   return true;
+}
+
+std::string CSettingControlSlider::GetDefaultFormatString() const
+{
+  if (m_format == "percentage")
+    return "{} %";
+  if (m_format == "integer")
+    return "{:d}";
+  if (m_format == "number")
+    return "{:.1f}";
+
+  return "{}";
 }
 
 bool CSettingControlRange::Deserialize(const TiXmlNode *node, bool update /* = false */)

--- a/xbmc/settings/SettingControl.h
+++ b/xbmc/settings/SettingControl.h
@@ -221,6 +221,7 @@ public:
   void SetFormatLabel(int formatLabel) { m_formatLabel = formatLabel; }
   const std::string& GetFormatString() const { return m_formatString; }
   void SetFormatString(const std::string &formatString) { m_formatString = formatString; }
+  std::string GetDefaultFormatString() const;
 
   SettingControlSliderFormatter GetFormatter() const { return m_formatter; }
   void SetFormatter(SettingControlSliderFormatter formatter) { m_formatter = formatter; }
@@ -229,7 +230,7 @@ protected:
   int m_heading = -1;
   bool m_popup = false;
   int m_formatLabel = -1;
-  std::string m_formatString = "%i";
+  std::string m_formatString;
   SettingControlSliderFormatter m_formatter = nullptr;
 };
 

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -9,6 +9,7 @@
 #include "SettingPath.h"
 
 #include "settings/lib/SettingsManager.h"
+#include "utils/FileExtensionProvider.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
@@ -44,7 +45,7 @@ bool CSettingPath::Deserialize(const TiXmlNode *node, bool update /* = false */)
     return false;
 
   if (m_control != nullptr &&
-     (m_control->GetType() != "button" || (m_control->GetFormat() != "path" && m_control->GetFormat() != "file")))
+     (m_control->GetType() != "button" || (m_control->GetFormat() != "path" && m_control->GetFormat() != "file" && m_control->GetFormat() != "image")))
   {
     CLog::Log(LOGERROR, "CSettingPath: invalid <control> of \"%s\"", m_id.c_str());
     return false;
@@ -91,7 +92,40 @@ bool CSettingPath::SetValue(const std::string &value)
   return CSettingString::SetValue(value);
 }
 
-void CSettingPath::copy(const CSettingPath &setting)
+std::string CSettingPath::GetMasking(const CFileExtensionProvider& fileExtensionProvider) const
+{
+  if (m_masking.empty())
+    return m_masking;
+
+  // setup masking
+  const auto audioMask = fileExtensionProvider.GetMusicExtensions();
+  const auto videoMask = fileExtensionProvider.GetVideoExtensions();
+  const auto imageMask = fileExtensionProvider.GetPictureExtensions();
+  auto execMask = "";
+#if defined(TARGET_WINDOWS)
+  execMask = ".exe|.bat|.cmd|.py";
+#endif // defined(TARGET_WINDOWS)
+
+  std::string masking = m_masking;
+  if (masking == "video")
+    return videoMask;
+  if (masking == "audio")
+    return audioMask;
+  if (masking == "image")
+    return imageMask;
+  if (masking == "executable")
+    return execMask;
+
+  // convert mask qualifiers
+  StringUtils::Replace(masking, "$AUDIO", audioMask);
+  StringUtils::Replace(masking, "$VIDEO", videoMask);
+  StringUtils::Replace(masking, "$IMAGE", imageMask);
+  StringUtils::Replace(masking, "$EXECUTABLE", execMask);
+
+  return masking;
+}
+
+void CSettingPath::copy(const CSettingPath& setting)
 {
   CSettingString::Copy(setting);
 

--- a/xbmc/settings/SettingPath.h
+++ b/xbmc/settings/SettingPath.h
@@ -12,6 +12,8 @@
 
 #include <vector>
 
+class CFileExtensionProvider;
+
 class CSettingPath : public CSettingString
 {
 public:
@@ -31,7 +33,7 @@ public:
   void SetSources(const std::vector<std::string> &sources) { m_sources = sources; }
   bool HideExtension() const { return m_hideExtension; }
   void SetHideExtension(bool hideExtension) { m_hideExtension = hideExtension; }
-  const std::string& GetMasking() const { return m_masking; }
+  std::string GetMasking(const CFileExtensionProvider& fileExtensionProvider) const;
   void SetMasking(const std::string& masking) { m_masking = masking; }
 
 private:

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -42,6 +42,29 @@ bool CheckSettingOptionsValidity(const TValue& value, const std::vector<TKey>& o
   return false;
 }
 
+bool DeserializeOptionsSort(const TiXmlElement* optionsElement, SettingOptionsSort& optionsSort)
+{
+  optionsSort = SettingOptionsSort::NoSorting;
+
+  std::string sort;
+  if (optionsElement->QueryStringAttribute("sort", &sort) != TIXML_SUCCESS)
+    return true;
+
+  if (StringUtils::EqualsNoCase(sort, "false") || StringUtils::EqualsNoCase(sort, "off") ||
+    StringUtils::EqualsNoCase(sort, "no") || StringUtils::EqualsNoCase(sort, "disabled"))
+    optionsSort = SettingOptionsSort::NoSorting;
+  else if (StringUtils::EqualsNoCase(sort, "asc") || StringUtils::EqualsNoCase(sort, "ascending") ||
+    StringUtils::EqualsNoCase(sort, "true") || StringUtils::EqualsNoCase(sort, "on") ||
+    StringUtils::EqualsNoCase(sort, "yes") || StringUtils::EqualsNoCase(sort, "enabled"))
+    optionsSort = SettingOptionsSort::Ascending;
+  else if (StringUtils::EqualsNoCase(sort, "desc") || StringUtils::EqualsNoCase(sort, "descending"))
+    optionsSort = SettingOptionsSort::Descending;
+  else
+    return false;
+
+  return true;
+}
+
 CSetting::CSetting(const std::string &id, CSettingsManager *settingsManager /* = nullptr */)
   : ISetting(id, settingsManager)
 { }
@@ -764,9 +787,12 @@ bool CSettingInt::Deserialize(const TiXmlNode *node, bool update /* = false */)
   if (constraints != nullptr)
   {
     // get the entries
-    auto options = constraints->FirstChild(SETTING_XML_ELM_OPTIONS);
+    auto options = constraints->FirstChildElement(SETTING_XML_ELM_OPTIONS);
     if (options != nullptr && options->FirstChild() != nullptr)
     {
+      if (!DeserializeOptionsSort(options, m_optionsSort))
+        CLog::Log(LOGWARNING, "CSettingInt: invalid \"sort\" attribute of <" SETTING_XML_ELM_OPTIONS "> for \"%s\"", m_id.c_str());
+
       if (options->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT)
       {
         m_optionsFillerName = options->FirstChild()->ValueStr();
@@ -1195,9 +1221,12 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
     XMLUtils::GetBoolean(constraints, SETTING_XML_ELM_ALLOWEMPTY, m_allowEmpty);
 
     // get the entries
-    auto options = constraints->FirstChild(SETTING_XML_ELM_OPTIONS);
+    auto options = constraints->FirstChildElement(SETTING_XML_ELM_OPTIONS);
     if (options != nullptr && options->FirstChild() != nullptr)
     {
+      if (!DeserializeOptionsSort(options, m_optionsSort))
+        CLog::Log(LOGWARNING, "CSettingInt: invalid \"sort\" attribute of <" SETTING_XML_ELM_OPTIONS "> for \"%s\"", m_id.c_str());
+
       if (options->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT)
       {
         m_optionsFillerName = options->FirstChild()->ValueStr();
@@ -1217,6 +1246,15 @@ bool CSettingString::Deserialize(const TiXmlNode *node, bool update /* = false *
           {
             entry.second = optionElement->FirstChild()->Value();
             m_translatableOptions.push_back(entry);
+          }
+          else
+          {
+            const std::string value = optionElement->FirstChild()->Value();
+            // if a specific "label" attribute is present use it otherwise use the value as label
+            std::string label = value;
+            optionElement->QueryStringAttribute(SETTING_XML_ATTR_LABEL, &label);
+
+            m_options.emplace_back(label, value);
           }
 
           optionElement = optionElement->NextSiblingElement(SETTING_XML_ELM_OPTION);

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -302,6 +302,8 @@ public:
     m_optionsFillerData = data;
   }
   IntegerSettingOptions UpdateDynamicOptions();
+  SettingOptionsSort GetOptionsSort() const { return m_optionsSort; }
+  void SetOptionsSort(SettingOptionsSort optionsSort) { m_optionsSort = optionsSort; }
 
 private:
   void copy(const CSettingInt &setting);
@@ -318,6 +320,7 @@ private:
   IntegerSettingOptionsFiller m_optionsFiller = nullptr;
   void *m_optionsFillerData = nullptr;
   IntegerSettingOptions m_dynamicOptions;
+  SettingOptionsSort m_optionsSort = SettingOptionsSort::NoSorting;
 };
 
 /*!
@@ -416,6 +419,8 @@ public:
     m_optionsFillerData = data;
   }
   StringSettingOptions UpdateDynamicOptions();
+  SettingOptionsSort GetOptionsSort() const { return m_optionsSort; }
+  void SetOptionsSort(SettingOptionsSort optionsSort) { m_optionsSort = optionsSort; }
 
 protected:
   virtual void copy(const CSettingString &setting);
@@ -429,6 +434,7 @@ protected:
   StringSettingOptionsFiller m_optionsFiller = nullptr;
   void *m_optionsFillerData = nullptr;
   StringSettingOptions m_dynamicOptions;
+  SettingOptionsSort m_optionsSort = SettingOptionsSort::NoSorting;
 };
 
 /*!

--- a/xbmc/settings/lib/SettingDefinitions.h
+++ b/xbmc/settings/lib/SettingDefinitions.h
@@ -98,3 +98,10 @@ using StringSettingOptions = std::vector<StringSettingOption>;
 class CSetting;
 using IntegerSettingOptionsFiller = void (*)(std::shared_ptr<const CSetting> setting, IntegerSettingOptions &list, int &current, void *data);
 using StringSettingOptionsFiller = void (*)(std::shared_ptr<const CSetting> setting, StringSettingOptions &list, std::string &current, void *data);
+
+enum class SettingOptionsSort
+{
+  NoSorting,
+  Ascending,
+  Descending
+};

--- a/xbmc/settings/windows/GUIControlSettings.h
+++ b/xbmc/settings/windows/GUIControlSettings.h
@@ -188,9 +188,11 @@ public:
   void Update(bool updateDisplayOnly = false) override;
   void Clear() override { m_pSlider = NULL; }
 
-  static std::string GetText(std::shared_ptr<const CSettingControlSlider> control, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum, ILocalizer* localizer);
+  static std::string GetText(std::shared_ptr<CSetting> setting, const CVariant &value, const CVariant &minimum, const CVariant &step, const CVariant &maximum, ILocalizer* localizer);
 
 private:
+  static bool FormatText(const std::string& formatString, const CVariant &value, const std::string& settingId, std::string& formattedText);
+
   CGUISettingsSliderControl *m_pSlider;
 };
 


### PR DESCRIPTION
[settings] add some missing functionality required for add-on settings

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
