### PR TITLE
'F11' keymap to toggle HDR on/off

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -167,6 +167,7 @@
       <k mod="ctrl,shift">ReloadKeymaps</k>
       <d mod="ctrl,shift">ToggleDebug</d>
       <r mod="ctrl,shift">ToggleDirtyRegionVisualization</r>
+      <f11>HDRToggle</f11>
     </keyboard>
   </global>
   <LoginScreen>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -490,12 +490,12 @@ bool CApplication::Create(const CAppParamParser &params)
   CLog::Log(LOGNOTICE, "%s", CWIN32Util::GetResInfoString().c_str());
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");
   CLog::Log(LOGNOTICE, "Aero is %s", (g_sysinfo.IsAeroDisabled() == true) ? "disabled" : "enabled");
-  int hDR = CWIN32Util::GetWindowsHDRStatus();
-  if (hDR > 0)
-    CLog::Log(LOGNOTICE, "HDR Display capable is detected and Windows HDR switch is %s",
-              (hDR == 2) ? "ON" : "OFF");
+  CWIN32Util::HDR_STATUS hdrStatus = CWIN32Util::GetWindowsHDRStatus();
+  if (hdrStatus == CWIN32Util::HDR_STATUS::HDR_UNSUPPORTED)
+    CLog::Log(LOGNOTICE, "Display is not HDR capable or cannot be detected");
   else
-    CLog::Log(LOGNOTICE, "Display is not HDR capable");
+    CLog::Log(LOGNOTICE, "Display HDR capable is detected and Windows HDR switch is %s",
+              (hdrStatus == CWIN32Util::HDR_STATUS::HDR_ON) ? "ON" : "OFF");
 #endif
 #if defined(TARGET_ANDROID)
   CLog::Log(LOGNOTICE,
@@ -1628,6 +1628,12 @@ bool CApplication::OnAction(const CAction &action)
   if (action.GetID() == ACTION_TAKE_SCREENSHOT)
   {
     CScreenShot::TakeScreenshot();
+    return true;
+  }
+  // Display HDR : toggle HDR on/off
+  if (action.GetID() == ACTION_HDR_TOGGLE)
+  {
+    CServiceBroker::GetWinSystem()->SetHDR(nullptr);
     return true;
   }
   // built in functions : execute the built-in

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -528,21 +528,6 @@ bool CProcessorHD::Render(CRect src, CRect dst, ID3D11Resource* target, CRenderB
     videoCtx1->VideoProcessorSetOutputColorSpace1(m_pVideoProcessor.Get(), target_color);
     // makes target available for processing in shaders
     videoCtx1->VideoProcessorSetOutputShaderUsage(m_pVideoProcessor.Get(), 1);
-
-    // only used for DXVA HW tone mapping HDR to SDR
-    if (!DX::Windowing()->IsHDROutput() && m_bSupportHDR10 &&
-        views[2]->color_transfer == AVCOL_TRC_SMPTE2084 && views[2]->primaries == AVCOL_PRI_BT2020)
-    {
-      ComPtr<ID3D11VideoContext2> videoCtx2;
-      if (SUCCEEDED(m_pVideoContext.As(&videoCtx2)))
-      {
-        // Passes stream SEI HDR metadata to VideoProcessor (refresh changes during playback)
-        DXGI_HDR_METADATA_HDR10 hdr10 = CRendererBase::GetDXGIHDR10MetaData(views[2]);
-        videoCtx2->VideoProcessorSetStreamHDRMetaData(m_pVideoProcessor.Get(), DEFAULT_STREAM_INDEX,
-                                                      DXGI_HDR_METADATA_TYPE_HDR10, sizeof(hdr10),
-                                                      &hdr10);
-      }
-    }
   }
   else
   {

--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -265,6 +265,8 @@
 #define ACTION_VOLUME_SET             245
 #define ACTION_TOGGLE_COMMSKIP        246
 
+#define ACTION_HDR_TOGGLE             247 //!< Toggle display HDR on/off
+
 #define ACTION_PLAYER_RESET           248 //!< Send a reset command to the active game
 
 #define ACTION_TOGGLE_FONT            249 //!< Toggle font. Used in TextViewer dialog

--- a/xbmc/input/actions/ActionTranslator.cpp
+++ b/xbmc/input/actions/ActionTranslator.cpp
@@ -202,6 +202,9 @@ static const std::map<ActionName, ActionID> ActionMappings =
     { "togglestereomode"         , ACTION_STEREOMODE_TOGGLE },
     { "stereomodetomono"         , ACTION_STEREOMODE_TOMONO },
 
+    // HDR display support
+    { "hdrtoggle"                , ACTION_HDR_TOGGLE},
+
     // PVR actions
     { "channelup"                , ACTION_CHANNEL_UP },
     { "channeldown"              , ACTION_CHANNEL_DOWN },

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -1341,10 +1341,10 @@ bool CWIN32Util::ToggleWindowsHDR()
 #endif
 }
 
-int CWIN32Util::GetWindowsHDRStatus()
+CWIN32Util::HDR_STATUS CWIN32Util::GetWindowsHDRStatus()
 {
 #ifdef TARGET_WINDOWS_STORE
-  int status = 0;
+  HDR_STATUS status = HDR_STATUS::HDR_UNSUPPORTED;
 
   auto displayInformation = DisplayInformation::GetForCurrentView();
 
@@ -1356,15 +1356,15 @@ int CWIN32Util::GetWindowsHDRStatus()
     {
       if (advancedColorInfo.CurrentAdvancedColorKind() == AdvancedColorKind::HighDynamicRange)
       {
-        status = 2;
+        status = HDR_STATUS::HDR_ON;
         if (CServiceBroker::IsServiceManagerUp())
-          CLog::LogF(LOGDEBUG, "CurrentAdvancedColorKind() = HDR, return status = {0:d}", status);
+          CLog::LogF(LOGDEBUG, "CurrentAdvancedColorKind() = HDR");
       }
       else if (advancedColorInfo.MaxLuminanceInNits() >= 400.0f)
       {
-        status = 1;
+        status = HDR_STATUS::HDR_OFF;
         if (CServiceBroker::IsServiceManagerUp())
-          CLog::LogF(LOGDEBUG, "MaxLuminanceInNits() >= 400, return status = {0:d}", status);
+          CLog::LogF(LOGDEBUG, "MaxLuminanceInNits() >= 400");
       }
     }
   }
@@ -1375,7 +1375,7 @@ int CWIN32Util::GetWindowsHDRStatus()
   uint32_t modeCount = 0;
   bool advancedColorSupported = false;
   bool advancedColorEnabled = false;
-  int status = 0;
+  HDR_STATUS status = HDR_STATUS::HDR_UNSUPPORTED;
 
   if (ERROR_SUCCESS == GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &pathCount, &modeCount))
   {
@@ -1411,25 +1411,23 @@ int CWIN32Util::GetWindowsHDRStatus()
 
       if (!advancedColorSupported)
       {
-        status = 0;
-        txStatus = "Display not HDR capable";
+        status = HDR_STATUS::HDR_UNSUPPORTED;
+        txStatus = "Display is not HDR capable or cannot be detected";
       }
       else if (advancedColorSupported && !advancedColorEnabled)
       {
-        status = 1;
-        txStatus = "Display HDR capable and current HDR status is disabled";
+        status = HDR_STATUS::HDR_OFF;
+        txStatus = "Display HDR capable and current HDR status is OFF";
       }
       else if (advancedColorSupported && advancedColorEnabled)
       {
-        status = 2;
-        txStatus = "Display HDR capable and current HDR status is enabled";
+        status = HDR_STATUS::HDR_ON;
+        txStatus = "Display HDR capable and current HDR status is ON";
       }
 
       // Prevents logging at application start before LOGLEVEL gets configured
       if (CServiceBroker::IsServiceManagerUp())
-      {
-        CLog::Log(LOGDEBUG, "{0:s} (status = {1:d})", txStatus, status);
-      }
+        CLog::Log(LOGDEBUG, "%s", txStatus);
     }
   }
 

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -65,6 +65,12 @@ public:
   static bool SetThreadLocalLocale(bool enable = true);
 
   // HDR display support
+  enum class HDR_STATUS : uint32_t
+  {
+    HDR_UNSUPPORTED = 0,
+    HDR_OFF         = 1,
+    HDR_ON          = 2
+  };
   static bool ToggleWindowsHDR();
-  static int GetWindowsHDRStatus();
+  static HDR_STATUS GetWindowsHDRStatus();
 };

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -112,6 +112,15 @@ void DX::DeviceResources::Release()
     m_d3dDebug = nullptr;
   }
 #endif
+
+  // Restores Windows HDR initial config
+  CWIN32Util::HDR_STATUS hdrStatus = CWIN32Util::GetWindowsHDRStatus();
+
+  if ((hdrStatus != CWIN32Util::HDR_STATUS::HDR_UNSUPPORTED && m_HDRWindows != hdrStatus))
+  {
+    if (CWIN32Util::ToggleWindowsHDR())
+      Sleep(2000);
+  }
 }
 
 void DX::DeviceResources::GetOutput(IDXGIOutput** ppOutput) const
@@ -289,19 +298,22 @@ bool DX::DeviceResources::SetFullScreen(bool fullscreen, RESOLUTION_INFO& res)
 void DX::DeviceResources::CreateDeviceIndependentResources()
 {
   // Configures Windows HDR according GUI Settings / Player / Use HDR display capabilities
+  CWIN32Util::HDR_STATUS hdrStatus = CWIN32Util::GetWindowsHDRStatus();
+  m_HDRWindows = hdrStatus; // Saves current Windows HDR status
+
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           Windowing()->SETTING_WINSYSTEM_IS_HDR_DISPLAY) &&
-      CWIN32Util::GetWindowsHDRStatus() == 1)
+      hdrStatus == CWIN32Util::HDR_STATUS::HDR_OFF)
   {
-    CWIN32Util::ToggleWindowsHDR(); // Toggle Windows HDR on
-    Sleep(2000);
+    if (CWIN32Util::ToggleWindowsHDR()) // Toggle Windows HDR on
+      Sleep(2000);
   }
   else if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                Windowing()->SETTING_WINSYSTEM_IS_HDR_DISPLAY) &&
-           CWIN32Util::GetWindowsHDRStatus() == 2)
+           hdrStatus == CWIN32Util::HDR_STATUS::HDR_ON)
   {
-    CWIN32Util::ToggleWindowsHDR(); // Toggle Windows HDR off
-    Sleep(2000);
+    if (CWIN32Util::ToggleWindowsHDR()) // Toggle Windows HDR off
+      Sleep(2000);
   }
 }
 

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -17,6 +17,7 @@
 
 #include "DirectXHelper.h"
 #include "guilib/D3DResource.h"
+#include "platform/win32/WIN32Util.h"
 
 struct RESOLUTION_INFO;
 
@@ -160,8 +161,11 @@ namespace DX
     Concurrency::critical_section m_criticalSection;
     Concurrency::critical_section m_resourceSection;
     std::vector<ID3DResource*> m_resources;
+
     bool m_stereoEnabled;
     bool m_bDeviceCreated;
     bool m_IsHDROutput;
+
+    CWIN32Util::HDR_STATUS m_HDRWindows;
   };
 }

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -169,7 +169,7 @@ bool CWinSystemWin10DX::SetHDR(const VideoPicture* videoPicture /*not used*/)
 
 bool CWinSystemWin10DX::IsHDRDisplay()
 {
-  if (CWIN32Util::GetWindowsHDRStatus() > 0)
+  if (CWIN32Util::GetWindowsHDRStatus() != CWIN32Util::HDR_STATUS::HDR_UNSUPPORTED)
     return true;
 
   return false;
@@ -177,7 +177,7 @@ bool CWinSystemWin10DX::IsHDRDisplay()
 
 bool CWinSystemWin10DX::GetOSHDRStatus()
 {
-  if (CWIN32Util::GetWindowsHDRStatus() == 2)
+  if (CWIN32Util::GetWindowsHDRStatus() == CWIN32Util::HDR_STATUS::HDR_ON)
     return true;
 
   return false;

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -394,7 +394,7 @@ bool CWinSystemWin32DX::SetHDR(const VideoPicture* videoPicture /*not used*/)
 
 bool CWinSystemWin32DX::IsHDRDisplay()
 {
-  if (CWIN32Util::GetWindowsHDRStatus() > 0)
+  if (CWIN32Util::GetWindowsHDRStatus() != CWIN32Util::HDR_STATUS::HDR_UNSUPPORTED)
     return true;
 
   return false;
@@ -402,7 +402,7 @@ bool CWinSystemWin32DX::IsHDRDisplay()
 
 bool CWinSystemWin32DX::GetOSHDRStatus()
 {
-  if (CWIN32Util::GetWindowsHDRStatus() == 2)
+  if (CWIN32Util::GetWindowsHDRStatus() == CWIN32Util::HDR_STATUS::HDR_ON)
     return true;
 
   return false;


### PR DESCRIPTION
Restores original Windows HDR config when Kodi exits
Refactor HDR display detection code
Removed unneeded code

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
