### PR TITLE
In Windows 10 is used swapchain with 6 backbuffers for all content HD…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -15,6 +15,7 @@
 #include "dialogs/GUIDialogBusy.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
+#include "HDRStatus.h"
 #include "interfaces/builtins/Builtins.h"
 #include "utils/JobManager.h"
 #include "utils/Variant.h"
@@ -490,12 +491,12 @@ bool CApplication::Create(const CAppParamParser &params)
   CLog::Log(LOGNOTICE, "%s", CWIN32Util::GetResInfoString().c_str());
   CLog::Log(LOGNOTICE, "Running with %s rights", (CWIN32Util::IsCurrentUserLocalAdministrator() == TRUE) ? "administrator" : "restricted");
   CLog::Log(LOGNOTICE, "Aero is %s", (g_sysinfo.IsAeroDisabled() == true) ? "disabled" : "enabled");
-  CWIN32Util::HDR_STATUS hdrStatus = CWIN32Util::GetWindowsHDRStatus();
-  if (hdrStatus == CWIN32Util::HDR_STATUS::HDR_UNSUPPORTED)
+  HDR_STATUS hdrStatus = CWIN32Util::GetWindowsHDRStatus();
+  if (hdrStatus == HDR_STATUS::HDR_UNSUPPORTED)
     CLog::Log(LOGNOTICE, "Display is not HDR capable or cannot be detected");
   else
     CLog::Log(LOGNOTICE, "Display HDR capable is detected and Windows HDR switch is %s",
-              (hdrStatus == CWIN32Util::HDR_STATUS::HDR_ON) ? "ON" : "OFF");
+              (hdrStatus == HDR_STATUS::HDR_ON) ? "ON" : "OFF");
 #endif
 #if defined(TARGET_ANDROID)
   CLog::Log(LOGNOTICE,

--- a/xbmc/CMakeLists.txt
+++ b/xbmc/CMakeLists.txt
@@ -61,6 +61,7 @@ set(HEADERS AppParamParser.h
             GUILargeTextureManager.h
             GUIPassword.h
             GUIUserMessages.h
+            HDRStatus.h
             IFileItemListModifier.h
             IProgressCallback.h
             InfoScanner.h

--- a/xbmc/HDRStatus.h
+++ b/xbmc/HDRStatus.h
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+enum class HDR_STATUS : uint32_t
+{
+  HDR_UNSUPPORTED = 0,
+  HDR_OFF         = 1,
+  HDR_ON          = 2
+};

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -16,6 +16,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
+#include "HDRStatus.h"
 #include "network/Network.h"
 #if defined(TARGET_DARWIN_OSX)
 #include "platform/darwin/osx/smc.h"
@@ -578,12 +579,10 @@ bool CSystemGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int context
       value = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_showExitButton;
       return true;
     case SYSTEM_IS_HDR_DISPLAY_OFF:
-      value = CServiceBroker::GetWinSystem()->IsHDRDisplay() &&
-              !CServiceBroker::GetWinSystem()->GetOSHDRStatus();
+      value = (HDR_STATUS::HDR_OFF == CServiceBroker::GetWinSystem()->GetOSHDRStatus());
       return true;
     case SYSTEM_IS_HDR_DISPLAY_ON:
-      value = CServiceBroker::GetWinSystem()->IsHDRDisplay() &&
-              CServiceBroker::GetWinSystem()->GetOSHDRStatus();
+      value = (HDR_STATUS::HDR_ON == CServiceBroker::GetWinSystem()->GetOSHDRStatus());
       return true;
     case SYSTEM_HAS_LOGINSCREEN:
       value = CServiceBroker::GetSettingsComponent()->GetProfileManager()->UsingLoginScreen();

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -1341,7 +1341,7 @@ bool CWIN32Util::ToggleWindowsHDR()
 #endif
 }
 
-CWIN32Util::HDR_STATUS CWIN32Util::GetWindowsHDRStatus()
+HDR_STATUS CWIN32Util::GetWindowsHDRStatus()
 {
 #ifdef TARGET_WINDOWS_STORE
   HDR_STATUS status = HDR_STATUS::HDR_UNSUPPORTED;

--- a/xbmc/platform/win32/WIN32Util.h
+++ b/xbmc/platform/win32/WIN32Util.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "HDRStatus.h"
 #include "URL.h"
 #include "utils/Geometry.h"
 
@@ -65,12 +66,6 @@ public:
   static bool SetThreadLocalLocale(bool enable = true);
 
   // HDR display support
-  enum class HDR_STATUS : uint32_t
-  {
-    HDR_UNSUPPORTED = 0,
-    HDR_OFF         = 1,
-    HDR_ON          = 2
-  };
   static bool ToggleWindowsHDR();
   static HDR_STATUS GetWindowsHDRStatus();
 };

--- a/xbmc/rendering/dx/DeviceResources.h
+++ b/xbmc/rendering/dx/DeviceResources.h
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include "DirectXHelper.h"
+#include "HDRStatus.h"
 #include "guilib/D3DResource.h"
 #include "platform/win32/WIN32Util.h"
 
@@ -166,6 +167,6 @@ namespace DX
     bool m_bDeviceCreated;
     bool m_IsHDROutput;
 
-    CWIN32Util::HDR_STATUS m_HDRWindows;
+    HDR_STATUS m_HDRWindows;
   };
 }

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "HDRStatus.h"
 #include "OSScreenSaver.h"
 #include "Resolution.h"
 #include "VideoSync.h"
@@ -157,7 +158,7 @@ public:
   std::shared_ptr<CDPMSSupport> GetDPMSManager();
   virtual bool SetHDR(const VideoPicture* videoPicture) { return false; };
   virtual bool IsHDRDisplay() { return false; };
-  virtual bool GetOSHDRStatus() { return false; };
+  virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; };
 
   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
 

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -169,18 +169,15 @@ bool CWinSystemWin10DX::SetHDR(const VideoPicture* videoPicture /*not used*/)
 
 bool CWinSystemWin10DX::IsHDRDisplay()
 {
-  if (CWIN32Util::GetWindowsHDRStatus() != CWIN32Util::HDR_STATUS::HDR_UNSUPPORTED)
+  if (CWIN32Util::GetWindowsHDRStatus() != HDR_STATUS::HDR_UNSUPPORTED)
     return true;
 
   return false;
 }
 
-bool CWinSystemWin10DX::GetOSHDRStatus()
+HDR_STATUS CWinSystemWin10DX::GetOSHDRStatus()
 {
-  if (CWIN32Util::GetWindowsHDRStatus() == CWIN32Util::HDR_STATUS::HDR_ON)
-    return true;
-
-  return false;
+  return CWIN32Util::GetWindowsHDRStatus();
 }
 
 bool CWinSystemWin10DX::IsHDROutput() const

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "HDRStatus.h"
 #include "WinSystemWin10.h"
 #include "rendering/dx/RenderSystemDX.h"
 
@@ -65,7 +66,7 @@ public:
   // HDR OS/display override
   bool SetHDR(const VideoPicture* videoPicture) override;
   bool IsHDRDisplay() override;
-  bool GetOSHDRStatus() override;
+  HDR_STATUS GetOSHDRStatus() override;
 
   // HDR support
   bool IsHDROutput() const;

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -394,18 +394,15 @@ bool CWinSystemWin32DX::SetHDR(const VideoPicture* videoPicture /*not used*/)
 
 bool CWinSystemWin32DX::IsHDRDisplay()
 {
-  if (CWIN32Util::GetWindowsHDRStatus() != CWIN32Util::HDR_STATUS::HDR_UNSUPPORTED)
+  if (CWIN32Util::GetWindowsHDRStatus() != HDR_STATUS::HDR_UNSUPPORTED)
     return true;
 
   return false;
 }
 
-bool CWinSystemWin32DX::GetOSHDRStatus()
+HDR_STATUS CWinSystemWin32DX::GetOSHDRStatus()
 {
-  if (CWIN32Util::GetWindowsHDRStatus() == CWIN32Util::HDR_STATUS::HDR_ON)
-    return true;
-
-  return false;
+  return CWIN32Util::GetWindowsHDRStatus();
 }
 
 bool CWinSystemWin32DX::IsHDROutput() const

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "HDRStatus.h"
 #include "rendering/dx/RenderSystemDX.h"
 #include "windowing/windows/WinSystemWin32.h"
 
@@ -67,7 +68,7 @@ public:
   // HDR OS/display override
   bool SetHDR(const VideoPicture* videoPicture) override;
   bool IsHDRDisplay() override;
-  bool GetOSHDRStatus() override;
+  HDR_STATUS GetOSHDRStatus() override;
 
   // HDR support
   bool IsHDROutput() const;


### PR DESCRIPTION
…R/SDR/3D

Moved enum class HDR_STATUS to a separate file
Simplified code to turn HDR ON/OFF when Kodi starts/exits
Refactored HDR detection code (windowing part)

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
