### PR TITLE
[Android] MediaCodec: Add support for AV1 Dolby Vision codec selection

### DIFF
--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -438,3 +438,14 @@ bool CAndroidUtils::SupportsMediaCodecMimeType(const std::string& mimeType)
 
   return false;
 }
+
+std::pair<bool, bool> CAndroidUtils::GetDolbyVisionCapabilities()
+{
+  const bool displaySupportsDovi = GetDisplayHDRCapabilities().SupportsDolbyVision();
+  const bool mediaCodecSupportsDovi = SupportsMediaCodecMimeType("video/dolby-vision");
+
+  CLog::Log(LOGDEBUG, "CAndroidUtils::GetDolbyVisionCapabilities Display: {}, MediaCodec: {}",
+            displaySupportsDovi, mediaCodecSupportsDovi);
+
+  return std::make_pair(displaySupportsDovi, mediaCodecSupportsDovi);
+}

--- a/xbmc/windowing/android/AndroidUtils.h
+++ b/xbmc/windowing/android/AndroidUtils.h
@@ -46,6 +46,7 @@ public:
 
   static std::vector<int> GetDisplaySupportedHdrTypes();
   static CHDRCapabilities GetDisplayHDRCapabilities();
+  static std::pair<bool, bool> GetDolbyVisionCapabilities();
 
 protected:
   mutable int m_width;


### PR DESCRIPTION
For AV1 files with Dolby Vision stream side data, the profile must be specified as the mime type is not enough to query the correct MediaCodec codec.

Also, some devices support AV1 Dolby Vision on API version < 30, so we should attempt to use the profile constant regardless of the API version.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
